### PR TITLE
Add zones to NAT Gateway IP config

### DIFF
--- a/nat_server.tf
+++ b/nat_server.tf
@@ -8,13 +8,15 @@ resource "azurerm_public_ip" "nat" {
   resource_group_name = azurerm_resource_group.nat.name
   location            = azurerm_resource_group.nat.location
   allocation_method   = "Static"
+  zones               = ["1"]
 }
 
 resource "azurerm_public_ip_prefix" "nat" {
   name                = "pippr-nat-uksouth-001"
   location            = azurerm_resource_group.nat.location
   resource_group_name = azurerm_resource_group.nat.name
-  prefix_length = 30
+  prefix_length       = 30
+  zones               = ["1"]
 }
 
 resource "azurerm_nat_gateway" "nat" {


### PR DESCRIPTION
Update the Public IP parts of the NAT Gateway config to include zones, thus matching the example config given by Terraform.